### PR TITLE
Document agents and Ollama client functions

### DIFF
--- a/agents/browser.py
+++ b/agents/browser.py
@@ -1,3 +1,5 @@
+"""Helpers for downloading web pages and extracting readable content."""
+
 import httpx, re, logging
 from bs4 import BeautifulSoup
 import trafilatura
@@ -9,13 +11,34 @@ HEADERS = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chr
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=8), reraise=True)
 async def fetch_html(url: str) -> str:
+    """Retrieve raw HTML for a given URL.
+
+    Args:
+        url: The web page to fetch.
+
+    Returns:
+        The page content as text.
+    """
+
     async with httpx.AsyncClient(timeout=30, headers=HEADERS, follow_redirects=True) as cx:
         r = await cx.get(url)
         r.raise_for_status()
         logger.debug("fetched %s", url)
         return r.text
 
-def extract_readable(html: str, url: str) -> dict:
+def extract_readable(html: str, url: str) -> dict[str, str]:
+    """Extract a readable document from HTML content.
+
+    Attempts to use *trafilatura* and falls back to BeautifulSoup if needed.
+
+    Args:
+        html: Raw HTML markup.
+        url: Source URL of the document.
+
+    Returns:
+        A dictionary containing ``title``, ``url`` and ``text`` keys.
+    """
+
     # trafilatura peut retourner None -> fallback BS4
     text = trafilatura.extract(html, url=url, include_tables=True, no_fallback=True)
     if not text:

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,3 +1,5 @@
+"""Planning agent for building URL lists with language model assistance."""
+
 from config import settings
 from services.ollama_client import generate
 
@@ -10,7 +12,21 @@ PROFILES = {
     "deep":     {"max_urls": 15, "task_tokens": 2500, "synth_tokens": 2500},
 }
 
-async def plan_urls(query: str, mode: str):
+async def plan_urls(query: str, mode: str) -> tuple[list[str], dict[str, int]]:
+    """Generate a list of relevant URLs for the given query.
+
+    Uses a small model to propose candidate URLs, then deduplicates and clamps
+    the results based on a profile selected by *mode*.
+
+    Args:
+        query: The user's search query.
+        mode: Name of the profile to use when planning.
+
+    Returns:
+        A tuple containing the final list of URLs and the profile configuration
+        that was applied.
+    """
+
     P = PROFILES.get(mode, PROFILES["balanced"])
     prompt = (
         "Liste 20 URLs pertinentes et récentes pour répondre à la question ci-dessous. "
@@ -23,6 +39,8 @@ async def plan_urls(query: str, mode: str):
     final, seen = [], set()
     for u in urls:
         if u not in seen:
-            final.append(u); seen.add(u)
-        if len(final) >= P["max_urls"]: break
+            final.append(u)
+            seen.add(u)
+        if len(final) >= P["max_urls"]:
+            break
     return final, P

--- a/agents/synth.py
+++ b/agents/synth.py
@@ -1,10 +1,23 @@
+"""Tools for generating final synthesis from collected documents."""
+
 from config import settings
 from services.ollama_client import generate
 
 DEFAULT_BIG = settings.default_big_model
 DEFAULT_SMALL = settings.default_small_model
 
-async def synthesize(query: str, docs: list[dict], task_tokens: int):
+async def synthesize(query: str, docs: list[dict[str, str]], task_tokens: int) -> str:
+    """Produce a structured summary from source documents.
+
+    Args:
+        query: The original user question.
+        docs: A list of documents with ``title``, ``url`` and ``text`` fields.
+        task_tokens: Token budget for the synthesis step.
+
+    Returns:
+        The generated synthesis text.
+    """
+
     corpus = "\n\n".join([f"### {d['title']}\nURL: {d['url']}\n{d['text']}" for d in docs])
     prompt = (
         "Tu es un assistant de recherche. Fournis une synthèse structurée, précise et neutre. "

--- a/services/ollama_client.py
+++ b/services/ollama_client.py
@@ -1,3 +1,5 @@
+"""Client utilities for interacting with local and remote Ollama instances."""
+
 import httpx, logging
 from tenacity import retry, stop_after_attempt, wait_exponential
 from config import settings
@@ -8,10 +10,30 @@ NAS_OLLAMA = settings.nas_ollama
 LAPTOP_OLLAMA = settings.laptop_ollama
 
 def _pick(task_tokens: int) -> str:
+    """Select the Ollama base URL based on the token budget.
+
+    Args:
+        task_tokens: Number of tokens requested for the task.
+
+    Returns:
+        The base URL of the chosen Ollama instance.
+    """
+
     return LAPTOP_OLLAMA if task_tokens > 1200 else NAS_OLLAMA
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
 async def generate(prompt: str, model: str, task_tokens: int = 800) -> str:
+    """Send a prompt to an Ollama model and return the generated response.
+
+    Args:
+        prompt: Text prompt to send to the model.
+        model: Name of the model to query.
+        task_tokens: Token budget, used to pick the server and context window.
+
+    Returns:
+        The text produced by the model.
+    """
+
     base = _pick(task_tokens)
     payload = {"model": model, "prompt": prompt, "stream": False}
     async with httpx.AsyncClient(timeout=120) as cx:


### PR DESCRIPTION
## Summary
- add module docstrings and return-type annotations in planning, browser and synthesis agents
- document `_pick` and `generate` helpers in Ollama client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a2231f7ec83209a9058cd3cccc0d9